### PR TITLE
Adds test for embedded shallow attributes with unexpected parameters

### DIFF
--- a/test/custom_types_test.rb
+++ b/test/custom_types_test.rb
@@ -152,5 +152,28 @@ describe ShallowAttributes do
         end
       end
     end
+    describe 'when custom type receives parameters not considered as attributes' do
+      let(:person) do
+        Person.new(
+            name: 'John',
+            address: {
+                street: 'Street',
+                number: '12'
+            }
+        )
+      end
+
+      it 'ignores the non existence parameter' do
+        hash = person.attributes
+        hash.must_equal({
+            name: 'John',
+            addresses: [],
+            address: {
+                street: 'Street',
+                zipcode: '111111'
+            }
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
## PROBLEM

Having two classes related like follow:

```ruby
class Address
  include ShallowAttributes

  attribute :street,  String
end

class Person
  include ShallowAttributes

  attribute :name,      String
  attribute :address,   Address
end
```

... when the embedded class receives parameters that doesn't match the defined attributes:

```ruby
{
    name: 'John',
        address: {
            street: 'Street',
            number: '12'
        }
}
```

... an error raises because doesn't find the definition in the class.

When a class including `ShallowAttribues` is initialized, during the initialization parameters non matching attributes are dismissed. But it doesn't happen during the lower levels in the hierarchy, because the objects are creating according to the type.  

## SOLUTION
Adding some logic during the `type` coercion and initialization avoid the conflict. 
